### PR TITLE
Various fixups

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -16,13 +16,14 @@ impl Builder {
     ///
     /// # Arguments
     /// * `permission` - permission
-    pub fn and<P>(&self, permission: P) -> Self
+    pub fn and<P>(mut self, permission: P) -> Self
     where
         P: Permission + 'static,
     {
-        let mut permissions: Vec<Box<dyn Permission>> = self.permissions.to_vec();
-        permissions.push(Box::new(permission));
-        Self { permissions }
+        self.permissions.push(Box::new(permission));
+        Self {
+            permissions: self.permissions,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@ where
     Args: FromRequest + 'static,
     F::Output: Responder,
 {
-    let new_perms = Arc::new(builder.permissions.to_vec());
+    let new_perms = Arc::new(builder.permissions);
     route.service(fn_factory(move || {
-        let new_perms_c = new_perms.clone();
+        let new_perms_c = Arc::clone(&new_perms);
         let handler = handler.clone();
         ready(Ok(PermissionService::new(new_perms_c, handler)))
     }))

--- a/src/permission.rs
+++ b/src/permission.rs
@@ -6,7 +6,7 @@ pub trait Permission: CloneablePermission {
     fn call(&self, req: &HttpRequest, payload: &mut Payload) -> Ready<actix_web::Result<bool>>;
 }
 
-/// CloneablePermission trait is needed for cloning a boxed trait object
+/// A trait needed for cloning a boxed trait object
 pub trait CloneablePermission {
     fn box_clone(&self) -> Box<dyn Permission>;
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -56,7 +56,7 @@ where
 
     fn call(&self, args: ServiceRequest) -> Self::Future {
         let (req, mut payload) = args.into_parts();
-        let perms = self.perms.clone();
+        let perms = Arc::clone(&self.perms);
         let handler = self.handler.clone();
 
         Box::pin(async move {


### PR DESCRIPTION
This just includes a few small fixups :)

* `Builder::and` and `check` had some unnecessary clones
* `CloneablePermission`'s doc comment is a little nicer
* Explicitly using `Arc::clone` to make things a little clearer