### PR TITLE
Fluent permissions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-permissions"
-version = "1.0.2"
+version = "2.0.0-beta.1"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-permissions"
-version = "2.0.0-beta.2"
+version = "2.0.0-beta.3"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-permissions"
-version = "2.0.0-beta.4"
+version = "2.0.0"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/lib.rs"
 
 [dependencies]
 actix-web = "4.0.1"
+futures-util = { version = "0.3.7", default-features = false }
+actix-http = "3.0.0-beta.18"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-permissions"
-version = "2.0.0-beta.3"
+version = "2.0.0-beta.4"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-permissions"
-version = "2.0.0-beta.1"
+version = "2.0.0-beta.2"
 edition = "2018"
 authors = ["Ana Bujan <ana@eisberg-labs.com>"]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ impl Permission<()> for IsAllowed {
 Dependencies:  
 ```toml
 [dependencies]
-actix-permissions = "1.0.0-beta.1"
+actix-permissions = "2.0.0"
 ```
 Code:
 ```rust
@@ -68,9 +68,16 @@ async fn index() -> Result<String, Error> {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        App::new()
-            .app_data(Data::new(DummyService))
-            .service(web::scope("").route("/", check(web::get(), dummy_permission_check, index)))
+        App::new().app_data(Data::new(DummyService)).service(
+            web::scope("").route(
+                "/",
+                permission()
+                    .check(web::get())
+                    .validate(dummy_permission_check)
+                    .to(index)
+                    .build(),
+            ),
+        )
     })
         .bind("127.0.0.1:8888")?
         .run()
@@ -87,6 +94,11 @@ access service request, payload and injected services.
 By default, 403 is returned for failed permission checks. You may want to toggle between `Unauthorized` and `Forbidden`,
 maybe customize 403 forbidden messages. That's why `check_with_custom_deny` is for.
 Take a look at [role based authorization example](./examples/role-based-authorization) for more info.
+
+## Permission chaining
+Not implemented more than one. It's because how it's implemented in `service.rs`. For every
+`Permission` there's a `FromRequest` impl. Every `FromRequest` consumes `Payload`, so `Payload` needs
+to be `cloned` each time. If you have a need for permission chaining or have an idea, open a [new Issue](https://github.com/eisberg-labs/actix-permissions/issues/new).
 
 ## Contributing
 

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -13,7 +13,7 @@ async fn dummy_permission_check(
     dummy_service: web::Data<DummyService>,
     data: web::Query<MyStatus>,
 ) -> actix_web::Result<bool> {
-    // Unecessary complicating permission check to show what it can do.
+    // Unnecessary complicating permission check to show what it can do.
     // You have access to request, payload, and all injected dependencies through app_data.
     Ok(dummy_service.check(data.status.clone()))
 }
@@ -33,9 +33,16 @@ async fn index() -> Result<String, Error> {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        App::new()
-            .app_data(Data::new(DummyService))
-            .service(web::scope("").route("/", check(web::get(), dummy_permission_check, index)))
+        App::new().app_data(Data::new(DummyService)).service(
+            web::scope("").route(
+                "/",
+                permission()
+                    .check(web::get())
+                    .validate(dummy_permission_check)
+                    .to(index)
+                    .build(),
+            ),
+        )
     })
     .bind("127.0.0.1:8888")?
     .run()

--- a/examples/role-based-authorization/src/permissions.rs
+++ b/examples/role-based-authorization/src/permissions.rs
@@ -1,7 +1,7 @@
 use crate::models::Role;
-use actix_permissions::check_with_custom_deny;
+use actix_permissions::builder::Builder;
 use actix_permissions::permission::Permission;
-use actix_web::{FromRequest, Handler, HttpMessage, HttpRequest, HttpResponse, Responder, Route};
+use actix_web::{FromRequest, Handler, HttpMessage, HttpRequest, HttpResponse, Responder};
 use std::future::{ready, Ready};
 
 #[derive(Clone)]
@@ -36,13 +36,13 @@ pub fn has_min_role(role: Role) -> RolePermissionCheck {
     RolePermissionCheck { role }
 }
 
-pub fn check<F, Args, P1, P1Args>(route: Route, permission: P1, handler: F) -> Route
+pub fn permission<F, Args, P1, P1Args>() -> Builder<F, Args, P1, P1Args>
 where
     F: Handler<Args>,
-    Args: FromRequest + 'static + Clone,
+    Args: FromRequest + 'static,
     P1: Permission<P1Args>,
-    P1Args: FromRequest + 'static + Clone,
+    P1Args: FromRequest + 'static,
     F::Output: Responder,
 {
-    check_with_custom_deny(route, permission, handler, custom_deny_handler)
+    actix_permissions::permission().with_deny_handler(custom_deny_handler)
 }

--- a/examples/role-based-authorization/src/routes.rs
+++ b/examples/role-based-authorization/src/routes.rs
@@ -17,17 +17,28 @@ async fn index() -> Result<String, Error> {
 }
 
 pub fn routes(cfg: &mut ServiceConfig) {
-    cfg.route("/", check(web::get(), has_min_role(Role::User), index))
-        .route(
-            "/admin",
-            check(
-                web::get(),
-                has_min_role(Role::Administrator),
-                administrators_index,
-            ),
-        )
-        .route(
-            "/mod",
-            check(web::get(), has_min_role(Role::Moderator), moderators_index),
-        );
+    cfg.route(
+        "/",
+        permission()
+            .check(web::get())
+            .validate(has_min_role(Role::User))
+            .to(index)
+            .build(),
+    )
+    .route(
+        "/admin",
+        permission()
+            .check(web::get())
+            .validate(has_min_role(Role::Administrator))
+            .to(administrators_index)
+            .build(),
+    )
+    .route(
+        "/mod",
+        permission()
+            .check(web::get())
+            .validate(has_min_role(Role::Moderator))
+            .to(moderators_index)
+            .build(),
+    );
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -41,31 +41,31 @@ where
     F::Output: Responder,
 {
     /// Appends route to builder.
-    pub fn check<'a>(&'a mut self, route: Route) -> &'a mut Self {
+    pub fn check(&mut self, route: Route) -> &mut Self {
         self.route = Some(route);
         self
     }
 
     /// Appends permission to builder.
-    pub fn validate<'a>(&'a mut self, permission: P1) -> &'a mut Self {
+    pub fn validate(&mut self, permission: P1) -> &mut Self {
         self.permission = Some(permission);
         self
     }
 
     /// Returns new builder with custom deny
-    pub fn with_deny_handler<'a>(&'a mut self, handler: fn(HttpRequest) -> HttpResponse) -> Self {
+    pub fn with_deny_handler(&mut self, handler: fn(HttpRequest) -> HttpResponse) -> Self {
         Self {
             route: self.route.take(),
             permission: self.permission.take(),
             handler: self.handler.take(),
             deny_handler: handler,
-            pd_handler: self.pd_handler.clone(),
+            pd_handler: self.pd_handler,
             pd_permission1: Default::default(),
         }
     }
 
     /// Appends handler to builder.
-    pub fn to<'a>(&'a mut self, handler: F) -> &'a mut Self {
+    pub fn to(&mut self, handler: F) -> &mut Self {
         self.handler = Some(handler);
         self
     }
@@ -73,7 +73,7 @@ where
     /// Builds a `Route` from permission `Builder` properties.
     /// `Route` that checks a `route` if passes a `permission`, then responds with `handler`.
     /// Otherwise a `deny_handler` is called.
-    pub fn build<'a>(&mut self) -> Route {
+    pub fn build(&mut self) -> Route {
         let permission = self.permission.take().unwrap();
         let handler = self.handler.take().unwrap();
         let deny_handler = self.deny_handler;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,101 @@
+//! [`Builder`] struct and function implementations.
+use std::future::ready;
+use std::marker::PhantomData;
+
+use actix_web::http::StatusCode;
+use actix_web::{FromRequest, Handler, HttpRequest, HttpResponse, Responder, Route};
+
+use crate::{fn_factory, Permission, PermissionService};
+
+/// Permission builder, combines route, handler and permission check, so
+/// you can write something more fluent like:
+/// ```
+/// use actix_web::web;
+/// use actix_web::HttpRequest;
+/// use actix_permissions::builder::Builder;
+///
+/// async fn permission_check(_req: HttpRequest) -> actix_web::Result<bool>{
+///     Ok(true)
+/// }
+/// async fn index() -> actix_web::Result<String> {
+///     Ok("".to_string())
+/// }
+///
+/// Builder::default().check(web::get()).is(permission_check).to(index);
+/// ```
+pub struct Builder<F, Args, P1, P1Args> {
+    route: Option<Route>,
+    permission: Option<P1>,
+    handler: Option<F>,
+    pd_handler: PhantomData<Args>,
+    deny_handler: fn(HttpRequest) -> HttpResponse,
+    pd_permission1: PhantomData<P1Args>,
+}
+
+impl<F, Args, P1, P1Args> Builder<F, Args, P1, P1Args>
+where
+    F: Handler<Args>,
+    Args: FromRequest + 'static,
+    P1: Permission<P1Args>,
+    P1Args: FromRequest + 'static,
+    F::Output: Responder,
+{
+    /// Appends route to builder.
+    pub fn check<'a>(&'a mut self, route: Route) -> &'a mut Self {
+        self.route = Some(route);
+        self
+    }
+
+    /// Appends permission to builder.
+    pub fn is<'a>(&'a mut self, permission: P1) -> &'a mut Self {
+        self.permission = Some(permission);
+        self
+    }
+
+    /// Appends deny handler to builder.
+    pub fn when_denied<'a>(&'a mut self, handler: fn(HttpRequest) -> HttpResponse) -> &'a mut Self {
+        self.deny_handler = handler;
+        self
+    }
+
+    /// Appends handler to builder.
+    pub fn to<'a>(&'a mut self, handler: F) -> &'a mut Self {
+        self.handler = Some(handler);
+        self
+    }
+
+    /// Builds a `Route` from permission `Builder` properties.
+    /// `Route` that checks a `route` if passes a `permission`, then responds with `handler`.
+    /// Otherwise a `deny_handler` is called.
+    pub fn build<'a>(&mut self) -> Route {
+        let permission = self.permission.take().unwrap();
+        let handler = self.handler.take().unwrap();
+        let deny_handler = self.deny_handler;
+
+        self.route.take().unwrap().service(fn_factory(move || {
+            ready(Ok(PermissionService::new(
+                permission.clone(),
+                handler.clone(),
+                deny_handler,
+            )))
+        }))
+    }
+}
+
+impl<F, Args, P1, P1Args> Default for Builder<F, Args, P1, P1Args> {
+    fn default() -> Self {
+        Self {
+            handler: None,
+            deny_handler: default_deny_handler,
+            permission: None,
+            pd_handler: PhantomData,
+            pd_permission1: PhantomData,
+            route: None,
+        }
+    }
+}
+
+/// Default deny handler, returns Forbidden.
+pub fn default_deny_handler(_req: HttpRequest) -> HttpResponse {
+    HttpResponse::new(StatusCode::FORBIDDEN)
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -52,10 +52,16 @@ where
         self
     }
 
-    /// Appends deny handler to builder.
-    pub fn when_denied<'a>(&'a mut self, handler: fn(HttpRequest) -> HttpResponse) -> &'a mut Self {
-        self.deny_handler = handler;
-        self
+    /// Returns new builder with custom deny
+    pub fn with_deny_handler<'a>(&'a mut self, handler: fn(HttpRequest) -> HttpResponse) -> Self {
+        Self {
+            route: self.route.take(),
+            permission: self.permission.take(),
+            handler: self.handler.take(),
+            deny_handler: handler,
+            pd_handler: self.pd_handler.clone(),
+            pd_permission1: Default::default(),
+        }
     }
 
     /// Appends handler to builder.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,7 +21,7 @@ use crate::{fn_factory, Permission, PermissionService};
 ///     Ok("".to_string())
 /// }
 ///
-/// Builder::default().check(web::get()).is(permission_check).to(index);
+/// Builder::default().check(web::get()).validate(permission_check).to(index);
 /// ```
 pub struct Builder<F, Args, P1, P1Args> {
     route: Option<Route>,
@@ -47,7 +47,7 @@ where
     }
 
     /// Appends permission to builder.
-    pub fn is<'a>(&'a mut self, permission: P1) -> &'a mut Self {
+    pub fn validate<'a>(&'a mut self, permission: P1) -> &'a mut Self {
         self.permission = Some(permission);
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ mod tests;
 /// async fn index() -> actix_web::Result<String> {
 ///     Ok("".to_string())
 /// }
-/// permission().check(web::get()).is(permission_check).to(index).build();
+/// permission().check(web::get()).validate(permission_check).to(index).build();
 /// ```
 pub fn permission<F, Args, P1, P1Args>() -> Builder<F, Args, P1, P1Args> {
     Builder::default()
@@ -45,7 +45,7 @@ where
     P1Args: FromRequest + 'static,
     F::Output: Responder,
 {
-    permission().check(route).is(perm).to(handler).build()
+    permission().check(route).validate(perm).to(handler).build()
 }
 
 /// Creates a more flexible route than `check`, which:
@@ -69,7 +69,7 @@ where
     permission()
         .with_deny_handler(deny_handler)
         .check(route)
-        .is(perm)
+        .validate(perm)
         .to(handler)
         .build()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ where
     F::Output: Responder,
 {
     permission()
-        .when_denied(deny_handler)
+        .with_deny_handler(deny_handler)
         .check(route)
         .is(perm)
         .to(handler)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,28 +2,42 @@
 //! With access to app data injections, HttpRequest and Payload.
 #![deny(missing_docs, rust_2018_idioms, elided_lifetimes_in_paths)]
 
-use std::future::ready;
-
 use actix_web::dev::fn_factory;
-use actix_web::http::StatusCode;
 use actix_web::{FromRequest, Handler, HttpRequest, HttpResponse, Responder, Route};
 
+use crate::builder::Builder;
 use crate::permission::Permission;
 use crate::service::PermissionService;
 
+pub mod builder;
 pub mod permission;
 pub mod service;
 mod tests;
 
-fn default_deny_handler(_req: HttpRequest) -> HttpResponse {
-    HttpResponse::new(StatusCode::FORBIDDEN)
+/// Shorthand for instantiating permissions [`Builder`]
+/// ```
+/// use actix_web::web;
+/// use actix_web::HttpRequest;
+/// use actix_permissions::permission;
+///
+/// async fn permission_check(_req: HttpRequest)->actix_web::Result<bool>{
+///     Ok(true)
+/// }
+/// async fn index() -> actix_web::Result<String> {
+///     Ok("".to_string())
+/// }
+/// permission().check(web::get()).is(permission_check).to(index).build();
+/// ```
+pub fn permission<F, Args, P1, P1Args>() -> Builder<F, Args, P1, P1Args> {
+    Builder::default()
 }
 
 /// Creates a route which:
 /// - intercepts requests and validates inputs.
 /// - if permission check is true, passes through to handler.
 /// - if permission check is false, `FORBIDDEN` is returned.
-pub fn check<F, Args, P1, P1Args>(route: Route, permission: P1, handler: F) -> Route
+#[deprecated(since = "2.0.0-beta.1", note = "please use `permission()` instead")]
+pub fn check<F, Args, P1, P1Args>(route: Route, perm: P1, handler: F) -> Route
 where
     F: Handler<Args>,
     Args: FromRequest + 'static,
@@ -31,16 +45,17 @@ where
     P1Args: FromRequest + 'static,
     F::Output: Responder,
 {
-    check_with_custom_deny(route, permission, handler, default_deny_handler)
+    permission().check(route).is(perm).to(handler).build()
 }
 
 /// Creates a more flexible route than `check`, which:
 /// - intercepts requests and validates inputs.
 /// - if permission checks are all true, passes through to handler.
 /// - if any of the permissions is false, `deny_handler` is called.
+#[deprecated(since = "2.0.0-beta.1", note = "please use `permission()` instead")]
 pub fn check_with_custom_deny<F, Args, P1, P1Args>(
     route: Route,
-    permission: P1,
+    perm: P1,
     handler: F,
     deny_handler: fn(HttpRequest) -> HttpResponse,
 ) -> Route
@@ -51,11 +66,10 @@ where
     P1Args: FromRequest + 'static,
     F::Output: Responder,
 {
-    route.service(fn_factory(move || {
-        ready(Ok(PermissionService::new(
-            permission.clone(),
-            handler.clone(),
-            deny_handler,
-        )))
-    }))
+    permission()
+        .when_denied(deny_handler)
+        .check(route)
+        .is(perm)
+        .to(handler)
+        .build()
 }

--- a/src/tests/test_service.rs
+++ b/src/tests/test_service.rs
@@ -1,10 +1,12 @@
 #[cfg(test)]
 mod tests {
     use crate::builder::default_deny_handler;
-    use actix_web::dev::Service;
+    use actix_http::body::MessageBody;
+    use actix_web::dev::{Service, ServiceResponse};
     use actix_web::http::StatusCode;
     use actix_web::{test, web, Error, HttpRequest, HttpResponse};
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
+    use std::str;
 
     use crate::service::PermissionService;
 
@@ -87,5 +89,45 @@ mod tests {
 
         let result = result.unwrap();
         assert_eq!(result.status(), StatusCode::BAD_REQUEST)
+    }
+
+    #[actix_web::test]
+    async fn test_validates_from_payload() {
+        #[derive(Clone, Debug, Serialize, Deserialize)]
+        struct TestStub {
+            param1: bool,
+        }
+        async fn check_json(
+            _req: HttpRequest,
+            data: web::Json<TestStub>,
+        ) -> actix_web::Result<bool> {
+            Ok(data.param1)
+        }
+        async fn index(data: web::Json<TestStub>) -> Result<String, Error> {
+            Ok(data.param1.to_string())
+        }
+
+        let service_req = test::TestRequest::post()
+            .set_json(&TestStub { param1: true })
+            .insert_header(("Content-type", "application/json"))
+            .to_srv_request();
+
+        let service = PermissionService::new(check_json, index, default_deny_handler);
+
+        let result = service.call(service_req).await;
+
+        assert!(result.is_ok());
+
+        let result = result.unwrap();
+        assert_eq!(result.status(), StatusCode::OK);
+
+        let res = response_as_string(result).await;
+        assert_eq!(res, "true".to_string());
+    }
+
+    /// Test helper method for extracting response as string
+    async fn response_as_string(resp: ServiceResponse) -> String {
+        let body_bytes = resp.into_body().try_into_bytes().unwrap().to_vec();
+        str::from_utf8(&body_bytes).unwrap().to_string()
     }
 }

--- a/src/tests/test_service.rs
+++ b/src/tests/test_service.rs
@@ -1,11 +1,11 @@
 #[cfg(test)]
 mod tests {
+    use crate::builder::default_deny_handler;
     use actix_web::dev::Service;
     use actix_web::http::StatusCode;
     use actix_web::{test, web, Error, HttpRequest, HttpResponse};
     use serde::Deserialize;
 
-    use crate::default_deny_handler;
     use crate::service::PermissionService;
 
     async fn index() -> Result<String, Error> {


### PR DESCRIPTION
- Changed to fluent writing permission in a route
- Deprecated `check` and `check_with_custom_deny` in favor of `permission()` builder.
- Fix disappearing `Payload` from handler.